### PR TITLE
dbカテゴリテーブル追加/記事作成時にカテゴリを選択式にするよう修正

### DIFF
--- a/app/assets/javascripts/categories.coffee
+++ b/app/assets/javascripts/categories.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/categories.scss
+++ b/app/assets/stylesheets/categories.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the Categories controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -1,0 +1,74 @@
+class CategoriesController < ApplicationController
+  before_action :set_category, only: [:show, :edit, :update, :destroy]
+
+  # GET /categories
+  # GET /categories.json
+  def index
+    @categories = Category.all
+  end
+
+  # GET /categories/1
+  # GET /categories/1.json
+  def show
+  end
+
+  # GET /categories/new
+  def new
+    @category = Category.new
+  end
+
+  # GET /categories/1/edit
+  def edit
+  end
+
+  # POST /categories
+  # POST /categories.json
+  def create
+    @category = Category.new(category_params)
+
+    respond_to do |format|
+      if @category.save
+        format.html { redirect_to @category, notice: 'Category was successfully created.' }
+        format.json { render :show, status: :created, location: @category }
+      else
+        format.html { render :new }
+        format.json { render json: @category.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  # PATCH/PUT /categories/1
+  # PATCH/PUT /categories/1.json
+  def update
+    respond_to do |format|
+      if @category.update(category_params)
+        format.html { redirect_to @category, notice: 'Category was successfully updated.' }
+        format.json { render :show, status: :ok, location: @category }
+      else
+        format.html { render :edit }
+        format.json { render json: @category.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  # DELETE /categories/1
+  # DELETE /categories/1.json
+  def destroy
+    @category.destroy
+    respond_to do |format|
+      format.html { redirect_to categories_url, notice: 'Category was successfully destroyed.' }
+      format.json { head :no_content }
+    end
+  end
+
+  private
+    # Use callbacks to share common setup or constraints between actions.
+    def set_category
+      @category = Category.find(params[:id])
+    end
+
+    # Never trust parameters from the scary internet, only allow the white list through.
+    def category_params
+      params.require(:category).permit(:name)
+    end
+end

--- a/app/controllers/edits_controller.rb
+++ b/app/controllers/edits_controller.rb
@@ -74,6 +74,6 @@ class EditsController < ApplicationController
 
     # Never trust parameters from the scary internet, only allow the white list through.
     def edit_params
-      params.require(:edit).permit(:user, :title, :date, :category, :text, :url)
+      params.require(:edit).permit(:user, :title, :date, :category_id, :text, :url)
     end
 end

--- a/app/helpers/categories_helper.rb
+++ b/app/helpers/categories_helper.rb
@@ -1,0 +1,2 @@
+module CategoriesHelper
+end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,0 +1,3 @@
+class Category < ApplicationRecord
+  has_many :edits
+end

--- a/app/models/edit.rb
+++ b/app/models/edit.rb
@@ -1,2 +1,6 @@
 class Edit < ApplicationRecord
+  validates_presence_of :title
+  validates_presence_of :date
+  validates_presence_of :text
+  belongs_to :category
 end

--- a/app/views/categories/_category.json.jbuilder
+++ b/app/views/categories/_category.json.jbuilder
@@ -1,0 +1,2 @@
+json.extract! category, :id, :name, :created_at, :updated_at
+json.url category_url(category, format: :json)

--- a/app/views/categories/_form.html.erb
+++ b/app/views/categories/_form.html.erb
@@ -1,0 +1,22 @@
+<%= form_for(category) do |f| %>
+  <% if category.errors.any? %>
+    <div id="error_explanation">
+      <h2><%= pluralize(category.errors.count, "error") %> prohibited this category from being saved:</h2>
+
+      <ul>
+      <% category.errors.full_messages.each do |message| %>
+        <li><%= message %></li>
+      <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div class="field">
+    <%= f.label :name %>
+    <%= f.text_field :name %>
+  </div>
+
+  <div class="actions">
+    <%= f.submit %>
+  </div>
+<% end %>

--- a/app/views/categories/edit.html.erb
+++ b/app/views/categories/edit.html.erb
@@ -1,0 +1,6 @@
+<h1>Editing Category</h1>
+
+<%= render 'form', category: @category %>
+
+<%= link_to 'Show', @category %> |
+<%= link_to 'Back', categories_path %>

--- a/app/views/categories/index.html.erb
+++ b/app/views/categories/index.html.erb
@@ -1,0 +1,27 @@
+<p id="notice"><%= notice %></p>
+
+<h1>Categories</h1>
+
+<table>
+  <thead>
+    <tr>
+      <th>Name</th>
+      <th colspan="3"></th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <% @categories.each do |category| %>
+      <tr>
+        <td><%= category.name %></td>
+        <td><%= link_to 'Show', category %></td>
+        <td><%= link_to 'Edit', edit_category_path(category) %></td>
+        <td><%= link_to 'Destroy', category, method: :delete, data: { confirm: 'Are you sure?' } %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+
+<br>
+
+<%= link_to 'New Category', new_category_path %>

--- a/app/views/categories/index.json.jbuilder
+++ b/app/views/categories/index.json.jbuilder
@@ -1,0 +1,1 @@
+json.array! @categories, partial: 'categories/category', as: :category

--- a/app/views/categories/new.html.erb
+++ b/app/views/categories/new.html.erb
@@ -1,0 +1,5 @@
+<h1>New Category</h1>
+
+<%= render 'form', category: @category %>
+
+<%= link_to 'Back', categories_path %>

--- a/app/views/categories/show.html.erb
+++ b/app/views/categories/show.html.erb
@@ -1,0 +1,9 @@
+<p id="notice"><%= notice %></p>
+
+<p>
+  <strong>Name:</strong>
+  <%= @category.name %>
+</p>
+
+<%= link_to 'Edit', edit_category_path(@category) %> |
+<%= link_to 'Back', categories_path %>

--- a/app/views/categories/show.json.jbuilder
+++ b/app/views/categories/show.json.jbuilder
@@ -1,0 +1,1 @@
+json.partial! "categories/category", category: @category

--- a/app/views/edits/_form.html.erb
+++ b/app/views/edits/_form.html.erb
@@ -27,8 +27,8 @@
   </div>
 
   <div class="field">
-    <%= f.label :category %>
-    <%= f.text_field :category %>
+    <%= f.label :category_id %>
+    <%= f.collection_select :category_id, Category.all, :id, :name %>
   </div>
 
   <div class="field">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
+  resources :categories
   devise_for :users
   get 'home/index'
  

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,27 +10,34 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171015023955) do
+ActiveRecord::Schema.define(version: 20171016061957) do
+
+  create_table "categories", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4" do |t|
+    t.string   "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
 
   create_table "edits", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4" do |t|
     t.string   "user"
     t.string   "title"
     t.date     "date"
-    t.string   "category"
-    t.text     "text",       limit: 16777215
+    t.text     "text",        limit: 65535
     t.string   "url"
-    t.datetime "created_at",                  null: false
-    t.datetime "updated_at",                  null: false
+    t.datetime "created_at",                null: false
+    t.datetime "updated_at",                null: false
+    t.integer  "category_id"
+    t.index ["category_id"], name: "index_edits_on_category_id", using: :btree
   end
 
   create_table "twitter_data", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4" do |t|
     t.string   "trend"
-    t.text     "tweet",      limit: 16777215
-    t.datetime "created_at",                  null: false
-    t.datetime "updated_at",                  null: false
+    t.text     "tweet",      limit: 65535
+    t.datetime "created_at",               null: false
+    t.datetime "updated_at",               null: false
   end
 
-  create_table "users", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1" do |t|
+  create_table "users", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4" do |t|
     t.string   "email",                  default: "", null: false
     t.string   "encrypted_password",     default: "", null: false
     t.string   "reset_password_token"
@@ -43,8 +50,8 @@ ActiveRecord::Schema.define(version: 20171015023955) do
     t.string   "last_sign_in_ip"
     t.datetime "created_at",                          null: false
     t.datetime "updated_at",                          null: false
-    t.index ["email"], name: "index_users_on_email", unique: true, using: :btree
-    t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree
+    t.index ["email"], name: "index_users_on_email", unique: true, length: { email: 191 }, using: :btree
+    t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, length: { reset_password_token: 191 }, using: :btree
   end
 
 end

--- a/test/controllers/categories_controller_test.rb
+++ b/test/controllers/categories_controller_test.rb
@@ -1,0 +1,48 @@
+require 'test_helper'
+
+class CategoriesControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @category = categories(:one)
+  end
+
+  test "should get index" do
+    get categories_url
+    assert_response :success
+  end
+
+  test "should get new" do
+    get new_category_url
+    assert_response :success
+  end
+
+  test "should create category" do
+    assert_difference('Category.count') do
+      post categories_url, params: { category: { name: @category.name } }
+    end
+
+    assert_redirected_to category_url(Category.last)
+  end
+
+  test "should show category" do
+    get category_url(@category)
+    assert_response :success
+  end
+
+  test "should get edit" do
+    get edit_category_url(@category)
+    assert_response :success
+  end
+
+  test "should update category" do
+    patch category_url(@category), params: { category: { name: @category.name } }
+    assert_redirected_to category_url(@category)
+  end
+
+  test "should destroy category" do
+    assert_difference('Category.count', -1) do
+      delete category_url(@category)
+    end
+
+    assert_redirected_to categories_url
+  end
+end

--- a/test/fixtures/categories.yml
+++ b/test/fixtures/categories.yml
@@ -1,0 +1,7 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  name: MyString
+
+two:
+  name: MyString

--- a/test/models/category_test.rb
+++ b/test/models/category_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class CategoryTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
カテゴリーのテーブル追加とeditsテーブルに外部キー導入しました。

合わせて記事作成時にカテゴリをdbから問い合わせしてプルダウン式に修正しました。

カテゴリーはmysqlに直接ログインしてinsert文で挿入してください
