### PR TITLE
記事詳細画面のカテゴリー表示のアドレス番地表示からnameの中身を表示に変更

### DIFF
--- a/app/views/edits/show.html.erb
+++ b/app/views/edits/show.html.erb
@@ -17,7 +17,7 @@
 
 <p>
   <strong>Category:</strong>
-  <%= @edit.category %>
+  <%= @edit.category.name %>
 </p>
 
 <p>


### PR DESCRIPTION
記事詳細画面のカテゴリー欄の不具合を修正