### PR TITLE
tweet取得時にAPIの残り制限を表示

### DIFF
--- a/lib/tasks/twitter.rake
+++ b/lib/tasks/twitter.rake
@@ -1,4 +1,5 @@
 require 'twitter'
+require 'oauth'
 
 namespace :twitter do
   desc "tweet hello"
@@ -11,6 +12,7 @@ namespace :twitter do
     tweet = "Hello Twitter!"
     #update(client, tweet)
     trend(client)
+    apiLimit
   end
 end
 
@@ -65,7 +67,7 @@ def search(client,word, count)
     'tweet' =>tweet.text,
     'tweet_id' =>tweet.id.to_s,
      #画像をnilとして保存
-    'image_url' =>nil, #とりあえずひとつだけ
+    'image_url' =>nil,
     'user' =>tweet.user.name,
     'user_id' =>tweet.user.screen_name, #userの@以下
     'user_icon_url' =>tweet.user.profile_image_url,
@@ -83,4 +85,25 @@ def trend(client)
     # trendに関するツイートを表示 引数: 検索ワード,件数
     search(client,trend.name, 10)
   end
+end
+
+def apiLimit
+  s = []
+  File.foreach("twitterOauth.txt") { |line|
+    s << line.chomp
+  }
+  client = OAuth::Consumer.new( #limitはTwitterGemでは提供されないので直接取得
+    s[0],
+    s[1],
+    site:'https://api.twitter.com/'
+  )
+  endpoint = OAuth::AccessToken.new(client, s[2], s[3])
+  response = endpoint.get('https://api.twitter.com/1.1/application/rate_limit_status.json')
+
+  response.header.each do |head|
+    print head + ':'
+    puts response.header[head]
+  end
+
+  puts response.body  
 end


### PR DESCRIPTION
仮実装

残り制限を表示するだけ
残り制限を取得するのもAPI残数を消費します。

見方、データの整形は後ほど。

tweetの取得のときと使用するGemが違うため、再度APIキーを取得しています。
