### PR TITLE
トレンドに関する修正

### DIFF
--- a/app/controllers/edits_controller.rb
+++ b/app/controllers/edits_controller.rb
@@ -2,6 +2,7 @@ class EditsController < ApplicationController
   before_action :set_edit, only: [:show, :edit, :update, :destroy]
 helper_method :twitter_datum_ids
 $twiGetId = Array.new
+$t = 0
   require 'date'
   # GET /edits
   # GET /edits.json
@@ -10,9 +11,7 @@ $twiGetId = Array.new
     @edits = Edit.all
     @articles = TwitterDatum.all
     @ed = EditsTwitter.all
- # 	 @articles = TwitterDatum.all.order(created_at: 'asc')
     @categories = Category.all
- 	 #@articles = TwitterDatum.all.order(created_at: 'desc')g
 
   end
 
@@ -24,10 +23,16 @@ $twiGetId = Array.new
 
   # GET /edits/new
   def new
+    #ページが再読み込みされるのでパラメータを保持
+    if params[:select_trend] == nil
+      params[:select_trend] = $t
+    else
+      $t = params[:select_trend]
+    end
     @edit = Edit.new
     @edits = Edit.all
     @articles = TwitterDatum.all.order(created_at: 'desc')
- 	 #@articles = TwitterDatum.all.order(created_at: 'desc')
+    @trend = Trend.find(params[:select_trend])
   end
 
   # GET /edits/1/edit
@@ -57,33 +62,7 @@ $twiGetId = Array.new
   def add
     $twiGetId << params[:id]
     $twiGetId.uniq!
-    # @getEdit = Edit.all.order(created_at: 'desc')
-# @edit = Edit.new(params[:id])
-# @edits[twitter_datum_ids] << selected_user.user_id
-#twitter_datum_ids << params[:id]
-#  hash = {id: twitter_datum_ids}
-#  require 'json'
-#  render :json => hash.to_json
-  # twi = EditsTwitter.new
-  #   twi.twitter_datum_id = params[:id]
-  #   @getEdit.each do |getedit|
-
-  #  edits_id = @getedit.id + 1
-
-  # end
-    # twi.edit_id = 36
-    # if twi.save #上の処理をするといらない
-    #   #head 201
-    #   user = TwitterDatum.find(twi.twitter_datum_id)
-    #   #ここの値がdataに入る
-    #   hash = {id: user.id, user: user.user,tweet: user.tweet}
-    #   require 'json'
-    #   render :json => hash.to_json
-    # else
-    #   head 500
-    # end
-
-end
+  end
 
   # PATCH/PUT /edits/1
   # PATCH/PUT /edits/1.json
@@ -117,7 +96,6 @@ end
 
     # Never trust parameters from the scary internet, only allow the white list through.
     def edit_params
-      # params.require(:edit).permit(:user, :title, :date, { :twitter_datum_ids=> [] }, :category_id, :text, :url)
       params.require(:edit).permit(:user, :title, :date, :category_id, :text, :url ,{ :twitter_datum_ids=> [] })
 
     end

--- a/app/controllers/edits_controller.rb
+++ b/app/controllers/edits_controller.rb
@@ -96,7 +96,6 @@ $t = 0
 
     # Never trust parameters from the scary internet, only allow the white list through.
     def edit_params
-      params.require(:edit).permit(:user, :title, :date, :category_id, :text, :url ,{ :twitter_datum_ids=> [] })
-
+      params.require(:edit).permit(:user, :title, :date, :category_id, :text, :url, { :twitter_datum_ids=> [] }, :trend_id)
     end
 end

--- a/app/controllers/trends_controller.rb
+++ b/app/controllers/trends_controller.rb
@@ -11,7 +11,7 @@ class TrendsController < ApplicationController
   private
     # Use callbacks to share common setup or constraints between actions.
     def set_trend
-      #@trend = Trend.find(params[:id])
+      @trend = Trend.find(params[:id])
     end
 
     # Never trust parameters from the scary internet, only allow the white list through.

--- a/app/controllers/trends_controller.rb
+++ b/app/controllers/trends_controller.rb
@@ -1,0 +1,21 @@
+class TrendsController < ApplicationController
+  before_action :set_trend, only: [:show, :edit, :update, :destroy]
+
+  # GET /trends
+  # GET /trends.json
+  def index
+    @trends = Trend.all
+  end
+
+
+  private
+    # Use callbacks to share common setup or constraints between actions.
+    def set_trend
+      #@trend = Trend.find(params[:id])
+    end
+
+    # Never trust parameters from the scary internet, only allow the white list through.
+    def trend_params
+      params.fetch(:trend, {})
+    end
+end

--- a/app/helpers/trends_helper.rb
+++ b/app/helpers/trends_helper.rb
@@ -1,0 +1,2 @@
+module TrendsHelper
+end

--- a/app/models/edit.rb
+++ b/app/models/edit.rb
@@ -3,6 +3,7 @@ class Edit < ApplicationRecord
   validates_presence_of :date
   validates_presence_of :text
   belongs_to :category
+  belongs_to :trend
   has_many :twitter_datum, :through => :edits_twitters, :source => :twitter_datum
   has_many :edits_twitters, foreign_key: 'edit_id'
   accepts_nested_attributes_for :edits_twitters, allow_destroy: true

--- a/app/models/trend.rb
+++ b/app/models/trend.rb
@@ -1,0 +1,4 @@
+class Trend < ApplicationRecord
+  has_many :twitter_datum, :through => :trend_twitters
+  has_many :twitter_datum, foreign_key: 'twitter_data_id'
+end

--- a/app/models/trend.rb
+++ b/app/models/trend.rb
@@ -1,4 +1,5 @@
 class Trend < ApplicationRecord
   has_many :twitter_data, :through => :trend_twitters
   has_many :trend_twitters, foreign_key: 'trend_id'
+  has_many :edits
 end

--- a/app/models/trend.rb
+++ b/app/models/trend.rb
@@ -1,4 +1,4 @@
 class Trend < ApplicationRecord
-  has_many :twitter_datum, :through => :trend_twitters
-  has_many :twitter_datum, foreign_key: 'twitter_data_id'
+  has_many :twitter_data, :through => :trend_twitters
+  has_many :trend_twitters, foreign_key: 'trend_id'
 end

--- a/app/models/trend_twitter.rb
+++ b/app/models/trend_twitter.rb
@@ -1,0 +1,4 @@
+class TrendTwitter < ApplicationRecord
+  belongs_to :trend
+  belongs_to :twitter_datum
+end

--- a/app/models/trend_twitter.rb
+++ b/app/models/trend_twitter.rb
@@ -1,4 +1,4 @@
 class TrendTwitter < ApplicationRecord
   belongs_to :trend
-  belongs_to :twitter_datum
+  belongs_to :twitter_datum, optional: true
 end

--- a/app/models/twitter_datum.rb
+++ b/app/models/twitter_datum.rb
@@ -3,6 +3,6 @@ class TwitterDatum < ApplicationRecord
   has_many :edits, :through => :edits_twitters
   has_many :edits_twitters, foreign_key: 'twitter_data_id'
   has_many :trends, :through => :trend_twitters
-  has_many :trend_twitters, foreign_key: 'trend_id'
+  has_many :trend_twitters, foreign_key: 'twitter_datum_id'
   accepts_nested_attributes_for :trend_twitters, allow_destroy: true
 end

--- a/app/models/twitter_datum.rb
+++ b/app/models/twitter_datum.rb
@@ -2,4 +2,7 @@ class TwitterDatum < ApplicationRecord
   validates :tweet_id, uniqueness: true
   has_many :edits, :through => :edits_twitters
   has_many :edits_twitters, foreign_key: 'twitter_data_id'
+  has_many :trends, :through => :trend_twitters
+  has_many :trend_twitters, foreign_key: 'trend_id'
+  accepts_nested_attributes_for :trend_twitters, allow_destroy: true
 end

--- a/app/views/edits/_form.html.erb
+++ b/app/views/edits/_form.html.erb
@@ -28,6 +28,12 @@
   </div>
 
   <div class="field">
+    <%= f.label :trend %>
+    <%= t = @trend.name %>
+    <%= f.hidden_field :trend_id, :value => @trend.id %>
+  </div>
+
+  <div class="field">
     <% $twiGetId.each do |twi| %>
     <!-- <%= hidden_field_tag 'twitter_datum_ids[]',twi %> -->
           <!-- multiple:配列を渡す -->

--- a/app/views/edits/index.html.erb
+++ b/app/views/edits/index.html.erb
@@ -107,7 +107,7 @@
 
         <br>
 
-        <%= link_to 'New Edit', new_edit_path %>
+        <%= link_to 'New Edit', trends_path %>
 
       </div>
     </div>

--- a/app/views/edits/index.html.erb
+++ b/app/views/edits/index.html.erb
@@ -113,7 +113,7 @@
     </div>
       <div class='article_left'>
         <h1>
-          過去記事
+          興味のある記事?
         </h1>
         <table class='scaffold_table'>
           <thead>

--- a/app/views/edits/new.html.erb
+++ b/app/views/edits/new.html.erb
@@ -10,23 +10,23 @@
     <th>tweet_time</th>
     <th>image_url</th>
   </tr>
-<% $twiGetId.each do |twi| %>
-<% @articles.where(id: twi).each do |art|%>
-<tr>
-  <td id='invisible_data'><%= art.id %></td>
-  <td><%= art.tweet %></td>
-  <td id='invisible_data'><%= art.tweet_id %></td>
-  <td><%= art.user %></td>
-  <td><%= art.user_id %></td>
-  <td><%= art.user_icon_url %></td>
-  <td><%= art.tweet_time %></td>
-  <% if art.image_url != nil  %>
-  <td style="text-align:center;"><img src="<%= art.image_url %>" alt="" width="100" height="100" style="border: solid 1px #000000;"/></td>
-  <% else %>
-  <td><%= art.image_url %></td>
-  <% end %>
-<% end %>
-</tr>
+  <% $twiGetId.each do |twi| %>
+    <% @articles.where(id: twi).each do |art|%>
+      <tr>
+        <td id='invisible_data'><%= art.id %></td>
+        <td><%= art.tweet %></td>
+        <td id='invisible_data'><%= art.tweet_id %></td>
+        <td><%= art.user %></td>
+        <td><%= art.user_id %></td>
+        <td><%= art.user_icon_url %></td>
+        <td><%= art.tweet_time %></td>
+        <% if art.image_url != nil  %>
+          <td style="text-align:center;"><img src="<%= art.image_url %>" alt="" width="100" height="100" style="border: solid 1px #000000;"/></td>
+        <% else %>
+          <td><%= art.image_url %></td>
+        <% end %>
+      </tr>
+    <% end %>
   <% end %>
   <tr>
     <!-- ドロップエリア -->
@@ -34,57 +34,44 @@
   </tr>
 </table>
 
-<h2>tweet
-</h2>
+<h2>tweet</h2>
 <div id="list">
-  <% str = '1111111111111111111111111111111111111111' %>
-  <% @articles.limit(100).each do |art|%>
+  <h2><%= @trend.name %></h2>
+  <% @trend.trend_twitters.each do |art|%>
 
-  <% if art.trend.to_s.include?(str.to_s)  %>
+    <table border="1" width="300">
+      <tr>
+        <th id='invisible_data'>id</th>
+        <th>tweet</th>
+        <th id='invisible_data'>tweet_id</th>
+        <th>user_name</th>
+        <th>user_id</th>
+        <th>user_icon_url</th>
+        <th>tweet_time</th>
+        <th>image_url</th>
+      </tr>
 
-  <% else %>
-
-<table border="1" width="300">
-  <h2><%= art.trend %></h2>
-  <tr>
-    <th id='invisible_data'>id</th>
-    <th>tweet</th>
-    <th id='invisible_data'>tweet_id</th>
-    <th>user_name</th>
-    <th>user_id</th>
-    <th>user_icon_url</th>
-    <th>tweet_time</th>
-    <th>image_url</th>
-  </tr>
-
-  <% str = art.trend %>
+    <tr class="item" draggable="true" >
+      <td id='invisible_data'><%= art.twitter_datum.id %></td>
+      <td><%= art.twitter_datum.tweet %></td>
+      <td id='invisible_data'><%= art.twitter_datum.tweet_id %></td>
+      <td><%= art.twitter_datum.user %></td>
+      <td><%= art.twitter_datum.user_id %></td>
+      <td><%= art.twitter_datum.user_icon_url %></td>
+      <td><%= art.twitter_datum.tweet_time %></td>
+      <% if art.twitter_datum.image_url != nil  %>
+        <td style="text-align:center;"><img src="<%= art.twitter_datum.image_url %>" alt="" width="100" height="100" style="border: solid 1px #000000;"/></td>
+      <% else %>
+        <td><%= art.twitter_datum.image_url %></td>
+      <% end %>
+    </tr>
+    <!-- DBの中に画像があれば画像を表示させる -->
+    <!-- 現在はサイズなどは適当に表示している -->
+    <!-- <% if art.twitter_datum.image_url != nil  %>
+      <p style="text-align:center;"><img src="<%= art.twitter_datum.image_url %>" alt="" width="327" height="328" style="border: solid 1px #000000;"/></p>
+    <% end %> -->
+    </table>
   <% end %>
-
-  <tr class="item" draggable="true" >
-    <td id='invisible_data'><%= art.id %></td>
-    <td><%= art.tweet %></td>
-    <td id='invisible_data'><%= art.tweet_id %></td>
-    <td><%= art.user %></td>
-    <td><%= art.user_id %></td>
-    <td><%= art.user_icon_url %></td>
-    <td><%= art.tweet_time %></td>
-    <% if art.image_url != nil  %>
-    <td style="text-align:center;"><img src="<%= art.image_url %>" alt="" width="100" height="100" style="border: solid 1px #000000;"/></td>
-    <% else %>
-    <td><%= art.image_url %></td>
-    <% end %>
-
-  </tr>
-
-
-<!-- DBの中に画像があれば画像を表示させる -->
-<!-- 現在はサイズなどは適当に表示している -->
-<!-- <% if art.image_url != nil  %>
-<p style="text-align:center;"><img src="<%= art.image_url %>" alt="" width="327" height="328" style="border: solid 1px #000000;"/></p>
-<% end %> -->
-<% end %>
-
-</table>
 </div>
 
 

--- a/app/views/edits/show.html.erb
+++ b/app/views/edits/show.html.erb
@@ -16,6 +16,11 @@
 </p>
 
 <p>
+  <strong>Trend:</strong>
+  <%= @edit.trend.name %>
+</p>
+
+<p>
   <strong>Tweet:</strong>
   <% @edit.edits_twitters.each do |twe| %>
    <table border="1">
@@ -30,7 +35,7 @@
       <!-- DBの中に画像があれば画像を表示させる -->
       <!-- 現在はサイズなどは適当に表示している -->
       <% if twe.twitter_datum.image_url != nil  %>
-<p style="text-align:center;"><img src="<%= twe.twitter_datum.image_url %>" alt="" width="327" height="328" style="border: solid 1px #000000;" /></p>
+        <p style="text-align:center;"><img src="<%= twe.twitter_datum.image_url %>" alt="" width="327" height="328" style="border: solid 1px #000000;" /></p>
       <% end %>
   <% end %>
 </p>

--- a/app/views/trends/index.html.erb
+++ b/app/views/trends/index.html.erb
@@ -1,0 +1,23 @@
+<p id="notice"><%= notice %></p>
+
+<h1>Trends</h1>
+
+<table>
+  <thead>
+    <tr>
+      <th colspan="3"></th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <% @trends.each do |trend| %>
+      <tr>
+        <td><%= trend.name %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+
+<br>
+
+<%= link_to 'back', edits_path %>

--- a/app/views/trends/index.html.erb
+++ b/app/views/trends/index.html.erb
@@ -12,7 +12,7 @@
   <tbody>
     <% @trends.each do |trend| %>
       <tr>
-        <td><%= trend.name %></td>
+        <td><%= link_to trend.name, new_edit_path(select_trend: trend.id) %></td>
       </tr>
     <% end %>
   </tbody>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,7 @@ Rails.application.routes.draw do
   post 'edits/add'
 
   resources :edits
+  resources :trends
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
   root :to => 'edits#index'
   #root :to => 'home#index'

--- a/db/migrate/20171109132915_create_trends.rb
+++ b/db/migrate/20171109132915_create_trends.rb
@@ -1,0 +1,8 @@
+class CreateTrends < ActiveRecord::Migration[5.0]
+  def change
+    create_table :trends do |t|
+      t.string :name
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20171109134052_create_trend_twitters.rb
+++ b/db/migrate/20171109134052_create_trend_twitters.rb
@@ -1,0 +1,10 @@
+class CreateTrendTwitters < ActiveRecord::Migration[5.0]
+  def change
+    create_table :trend_twitters do |t|
+      t.references :trend, foreign_key: true
+      t.references :twitter_datum, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20171110141246_add_trend_id_to_edits.rb
+++ b/db/migrate/20171110141246_add_trend_id_to_edits.rb
@@ -1,0 +1,6 @@
+class AddTrendIdToEdits < ActiveRecord::Migration[5.0]
+  def change 
+    add_column(:edits, :trend_id, :integer)
+    add_index(:edits, :trend_id)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171024142246) do
+ActiveRecord::Schema.define(version: 20171109134052) do
 
   create_table "categories", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4" do |t|
     t.string   "name"
@@ -37,6 +37,22 @@ ActiveRecord::Schema.define(version: 20171024142246) do
     t.datetime "updated_at",       null: false
     t.index ["edit_id"], name: "index_edits_twitters_on_edit_id", using: :btree
     t.index ["twitter_datum_id"], name: "index_edits_twitters_on_twitter_datum_id", using: :btree
+  end
+
+  create_table "trend_twitters", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4" do |t|
+    t.integer  "trend_id"
+    t.integer  "twitter_datum_id"
+    t.datetime "created_at",       null: false
+    t.datetime "updated_at",       null: false
+    t.index ["trend_id"], name: "index_trend_twitters_on_trend_id", using: :btree
+    t.index ["twitter_datum_id"], name: "index_trend_twitters_on_twitter_datum_id", using: :btree
+  end
+
+  create_table "trends", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4" do |t|
+    t.string   "name"
+    t.string   "trend_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "twitter_data", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4" do |t|
@@ -72,4 +88,6 @@ ActiveRecord::Schema.define(version: 20171024142246) do
 
   add_foreign_key "edits_twitters", "edits"
   add_foreign_key "edits_twitters", "twitter_data"
+  add_foreign_key "trend_twitters", "trends"
+  add_foreign_key "trend_twitters", "twitter_data"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171109134052) do
+ActiveRecord::Schema.define(version: 20171110141246) do
 
   create_table "categories", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4" do |t|
     t.string   "name"
@@ -27,7 +27,9 @@ ActiveRecord::Schema.define(version: 20171109134052) do
     t.datetime "created_at",                null: false
     t.datetime "updated_at",                null: false
     t.integer  "category_id"
+    t.integer  "trend_id"
     t.index ["category_id"], name: "index_edits_on_category_id", using: :btree
+    t.index ["trend_id"], name: "index_edits_on_trend_id", using: :btree
   end
 
   create_table "edits_twitters", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4" do |t|

--- a/lib/tasks/twitter.rake
+++ b/lib/tasks/twitter.rake
@@ -42,7 +42,7 @@ def update(client, tweet)
   end
 end
 
-def search(client, word, count)
+def search(client, word, count, trend_id)
   i = 0
   client.search(word, exclude: "retweets").take(count).each do |tweet|
     # ツイートにurlが含まれるか確認
@@ -80,7 +80,15 @@ def search(client, word, count)
       }
     end
     if TwitterDatum.create(tweet)
-      i += 1
+      trend_twitter = {
+        'twitter_datum_id' => TwitterDatum.last.id,
+        'trend_id' => trend_id
+      }
+      if TrendTwitter.create(trend_twitter)
+        i += 1
+      else
+        print("中間テーブル作成失敗, トレンド: #{word}, tweet: #{tweet_id}\n")
+      end
     end
   end
   print("トレンド: #{word}, 件数: #{i}件保存\n")
@@ -88,9 +96,22 @@ end
 
 def trend(client)
   client.trends_place(23424856).take(5).each do |trend| # 23424856:日本のtrend
-
+    t = Trend.find_by(name: trend.name)
+    if t == nil
+      trend_new = {
+        'name' => trend.name
+      }
+      if Trend.create(trend_new)
+        t_id = Trend.last.id
+      else
+        puts("トレンドの取得に失敗")
+        return
+      end
+    else
+      t_id = t.id
+    end
     # trendに関するツイートを表示 引数: 検索ワード,件数
-    search(client,trend.name, 3)
+    search(client,trend.name, 3, t_id)
   end
 end
 

--- a/test/controllers/trends_controller_test.rb
+++ b/test/controllers/trends_controller_test.rb
@@ -1,0 +1,48 @@
+require 'test_helper'
+
+class TrendsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @trend = trends(:one)
+  end
+
+  test "should get index" do
+    get trends_url
+    assert_response :success
+  end
+
+  test "should get new" do
+    get new_trend_url
+    assert_response :success
+  end
+
+  test "should create trend" do
+    assert_difference('Trend.count') do
+      post trends_url, params: { trend: {  } }
+    end
+
+    assert_redirected_to trend_url(Trend.last)
+  end
+
+  test "should show trend" do
+    get trend_url(@trend)
+    assert_response :success
+  end
+
+  test "should get edit" do
+    get edit_trend_url(@trend)
+    assert_response :success
+  end
+
+  test "should update trend" do
+    patch trend_url(@trend), params: { trend: {  } }
+    assert_redirected_to trend_url(@trend)
+  end
+
+  test "should destroy trend" do
+    assert_difference('Trend.count', -1) do
+      delete trend_url(@trend)
+    end
+
+    assert_redirected_to trends_url
+  end
+end

--- a/test/fixtures/trend_twitters.yml
+++ b/test/fixtures/trend_twitters.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  trend: one
+  twitter_datum: one
+
+two:
+  trend: two
+  twitter_datum: two

--- a/test/fixtures/trends.yml
+++ b/test/fixtures/trends.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the '{}' from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/models/trend_test.rb
+++ b/test/models/trend_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class TrendTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/trend_twitter_test.rb
+++ b/test/models/trend_twitter_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class TrendTwitterTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
トレンドを中間テーブルで管理する試用に変更

トレンド一覧から記事新規作成画面へ飛ぶよう変更
記事新規作成画面は選択されたトレンドのみを表示するよう変更
記事カラムにトレンド情報を追加

rake db:migrate:resetが必要