### PR TITLE
dropAreaにulを追加

### DIFF
--- a/app/views/edits/new.html.erb
+++ b/app/views/edits/new.html.erb
@@ -83,7 +83,7 @@
     <h3>枠内に要素をドロップする</h3>
 <div>
     <div id="dropArea" class="dropArea">
-
+    <ul></ul>
 </div>
 </div>
 


### PR DESCRIPTION
jqueryのsortableを使用する際中身が空の場合がエラーが起きるため
初期値<ul></ul>を入れておく。