### PR TITLE
記事作成においてツイートがDBに登録されまいバグを修正

### DIFF
--- a/app/controllers/edits_controller.rb
+++ b/app/controllers/edits_controller.rb
@@ -1,13 +1,14 @@
 class EditsController < ApplicationController
   before_action :set_edit, only: [:show, :edit, :update, :destroy]
 helper_method :twitter_datum_ids
-$twiGetId = Array.new
-$t = 0
+@@twiGetId = Array.new
+@@t = 0
   require 'date'
   # GET /edits
   # GET /edits.json
+
   def index
-    $twiGetId = Array.new
+    @@twiGetId = Array.new
     @edits = Edit.includes(:User).includes(:category)
     @articles = TwitterDatum.all
     @ed = EditsTwitter.all
@@ -20,17 +21,19 @@ $t = 0
   # GET /edits/1
   # GET /edits/1.json
   def show
-    $twiGetId = Array.new
+    @@twiGetId = Array.new
     @twes = @edit.edits_twitters.includes(:twitter_datum)
   end
 
   # GET /edits/new
   def new
+    @@twiGetId = Array.new
+    logger.debug("Log0 : " + @@twiGetId.to_s)
     #ページが再読み込みされるのでパラメータを保持
     if params[:select_trend] == nil
-      params[:select_trend] = $t
+      params[:select_trend] = @@t
     else
-      $t = params[:select_trend]
+      @@t = params[:select_trend]
     end
     @edit = Edit.new
     @edits = Edit.all
@@ -43,12 +46,22 @@ $t = 0
   def edit
     @trend = Trend.find(@edit.trend_id)
   end
+  # ドラッグアンドドロップされた時に呼ばれる
+    def add
+      @@twiGetId = Array.new
+      logger.debug("Log1 : " + params[:id].to_s)
+      params[:id].each do |twi_id|
+        @@twiGetId.push(twi_id)
+      end
+      @@twiGetId.uniq!
+      logger.debug("Log1 : " + @@twiGetId.to_s)
+    end
 
   # POST /edits
   # POST /edits.json
   def create
     @edit = Edit.new(edit_params)
-    @edit.twitter_datum_ids = $twiGetId
+    @edit.twitter_datum_ids = @@twiGetId
     @articles = TwitterDatum.all.order(created_at: 'desc')
     respond_to do |format|
       if @edit.save!
@@ -59,12 +72,6 @@ $t = 0
         format.json { render json: @edit.errors, status: :unprocessable_entity }
       end
     end
-  end
-
-# ドラッグアンドドロップされた時に呼ばれる
-  def add
-    $twiGetId << params[:id]
-    $twiGetId.uniq!
   end
 
   # PATCH/PUT /edits/1
@@ -99,6 +106,7 @@ $t = 0
 
     # Never trust parameters from the scary internet, only allow the white list through.
     def edit_params
-      params.require(:edit).permit(:title, :date, :category_id, :text, :url, { :twitter_datum_ids=> [] }, :trend_id, :User_id)
+      logger.debug("Log3 : " + @@twiGetId.to_s)
+      params.require(:edit).permit(:title, :date, :category_id, :text, :url, :trend_id, :User_id)
     end
 end

--- a/app/views/edits/_form.html.erb
+++ b/app/views/edits/_form.html.erb
@@ -34,14 +34,6 @@
     <%= f.hidden_field :trend_id, :value => @trend.id %>
   </div>
 
-  <div class="field">
-    <% $twiGetId.each do |twi| %>
-    <!-- <%= hidden_field_tag 'twitter_datum_ids[]',twi %> -->
-          <!-- multiple:配列を渡す -->
-            <%= f.hidden_field( :twitter_datum_ids,  :multiple => true, :value => twi) %>
-        <% end %>
-
-  </div>
 
   <div class="field">
     <%= f.label :category_id %>

--- a/app/views/edits/new.html.erb
+++ b/app/views/edits/new.html.erb
@@ -2,19 +2,9 @@
 <html lang="ja">
 <head>
     <meta charset="UTF-8">
-    <script src="http://kazefuku.net/sample/jQueryDnD/js/jquery-ui-1.8.20/jquery-1.7.2.js"></script>
-    <script src="http://kazefuku.net/sample/jQueryDnD/js/jquery-ui-1.8.20/ui/jquery.ui.core.js"></script>
-    <script src="http://kazefuku.net/sample/jQueryDnD/js/jquery-ui-1.8.20/ui/jquery.ui.widget.js"></script>
-    <script src="http://kazefuku.net/sample/jQueryDnD/js/jquery-ui-1.8.20/ui/jquery.ui.mouse.js"></script>
-    <script src="http://kazefuku.net/sample/jQueryDnD/js/jquery-ui-1.8.20/ui/jquery.ui.draggable.js"></script>
-    <script src="http://kazefuku.net/sample/jQueryDnD/js/jquery-ui-1.8.20/ui/jquery.ui.sortable.js"></script>
-    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js"></script>
-<script src="https://ajax.googleapis.com/ajax/libs/jqueryui/1.12.1/jquery-ui.min.js"></script>
-
-<script src="https://code.jquery.com/jquery-1.12.4.js"></script>
-<script src="https://code.jquery.com/ui/1.12.1/jquery-ui.js"></script>
-
-    <link rel="stylesheet" href="http://kazefuku.net/sample/jQueryDnD/js/jquery-ui-1.8.20/themes/base/jquery.ui.theme.css">
+    <script src="//code.jquery.com/jquery-1.12.4.js"></script>
+    <script src="//code.jquery.com/ui/1.12.1/jquery-ui.js"></script>
+    <link rel="stylesheet" href="//kazefuku.net/sample/jQueryDnD/js/jquery-ui-1.8.20/themes/base/jquery.ui.theme.css">
 
 <%= stylesheet_link_tag 'newArticleEdit' , :media => "all" %>
 
@@ -61,9 +51,11 @@
 </div>
 <script>
 var getTwiId = [];
+$("#dropArea").sortable({
+  }).disableSelection();
 
   $(function () {
-
+ console.info("jQuery = " + $.fn.jquery);
     // dropzoneの表示テキストを初期化
     // initDropzone();
 
@@ -98,17 +90,19 @@ var getTwiId = [];
     function doAction(id,name,tweet_id,tweet,user_id,icon,date,img_url) {
 
       console.log('Log1 : ' + img_url)
+      if (id != null) {
 if (img_url != '') {
 $('#dropArea').append('<ul><li>'+ id +'</li><li>'+ tweet +'</li><li>'+ tweet_id +'</li><li>'+ name +'</li><li>'+ user_id +'</li><li>'+ icon +'</li><li style="text-align:center;"><img src='+img_url+' alt="" width="100" height="100" style="border: solid 1px #000000;"></li></ul>');
 }
 else {
   $('#dropArea').append('<ul><li>'+ id +'</li><li>'+ tweet +'</li><li>'+ tweet_id +'</li><li>'+ name +'</li><li>'+ user_id +'</li><li>'+ icon +'</li></ul>');
 }
+}
 
-$( "#dropArea" ).sortable({
-  }).disableSelection();
 
+      if (id != null) {
       getTwiId.push(id)
+    }
       console.log(getTwiId)
 
       $.ajax(
@@ -116,7 +110,7 @@ $( "#dropArea" ).sortable({
         url: "<%=  edits_add_path  %>",
         type: "POST",
         data: {
-          id: id
+          id: getTwiId
         },
         dataType: "html",
         success: function (data) {
@@ -227,6 +221,7 @@ $( "#dropArea" ).sortable({
       var img_url = e.originalEvent.dataTransfer.getData('img_url');
       // endDropzone(name);
       doAction(id,name,tweet_id,tweet,user_id,icon,date,img_url);
+      doAction(null,name,tweet_id,tweet,user_id,icon,date,img_url);
       onHidden(tweet_id);
     }
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -75,7 +75,8 @@
     </div>
 
 
-    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
+    <script src="//code.jquery.com/jquery-1.12.4.js"></script>
+    <script src="//code.jquery.com/ui/1.12.1/jquery-ui.js"></script>
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
     </body>
 </html>


### PR DESCRIPTION
記事作成画面でツイートがDBに登録されないバグを修正しました。
変更内容
グローバル変数をクラス変数に変換。
記事作成フォームの隠しタグを消去（使っていないため）
application.html.erbで3.x系のjqueryを使用していたため記事作成画面で
jsの競合が発生したので、jqueryを1.12系に統一（sortable使用のため）
記事作成画面で不要なjsの読み込みを消去


バグ内容
・ajaxで送ったデータをコントローラでクラス変数に格納
・viewのフォームを送信した際に得るコントローラの上記のクラス変数にずれ？（一回分遅い）が生じている。

対策
・ajax通信を2重で送り一回分のずれを強制的に合わせる。

