### PR TITLE
Feature/bug fix

### DIFF
--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -10,7 +10,7 @@ class CategoriesController < ApplicationController
   # GET /categories/1
   # GET /categories/1.json
   def show
-    @edits = Edit.where(category_id: params[:id]).includes(:User)
+    @edits = Edit.where(category_id: params[:id]).includes(:User).order(created_at: 'desc')
   end
 
   # GET /categories/new

--- a/app/controllers/edits_controller.rb
+++ b/app/controllers/edits_controller.rb
@@ -10,12 +10,12 @@ helper_method :twitter_datum_ids
 
   def index
     @user = current_user
-    @edits = Edit.includes(:User).includes(:category)
+    @edits = Edit.includes(:User).includes(:category).order(created_at: 'desc')
     @articles = TwitterDatum.all.order(created_at: 'desc')
     @ed = EditsTwitter.all.order(created_at: 'desc')
     @categories = Category.all
     #今日の日付が取れないので昨日+1で対応
-    @trends = Trend.where('updated_at > ?', DateTime.yesterday+1)
+    @trends = Trend.where('updated_at > ?', DateTime.yesterday+1).order(created_at: 'desc')
   end
 
   # GET /edits/1

--- a/app/controllers/edits_controller.rb
+++ b/app/controllers/edits_controller.rb
@@ -11,8 +11,8 @@ helper_method :twitter_datum_ids
   def index
     @user = current_user
     @edits = Edit.includes(:User).includes(:category)
-    @articles = TwitterDatum.all
-    @ed = EditsTwitter.all
+    @articles = TwitterDatum.all.order(created_at: 'desc')
+    @ed = EditsTwitter.all.order(created_at: 'desc')
     @categories = Category.all
     #今日の日付が取れないので昨日+1で対応
     @trends = Trend.where('updated_at > ?', DateTime.yesterday+1)
@@ -63,7 +63,7 @@ render :json => hash.to_json
   #GET /edits/list
   def list
     @q = Edit.includes(:User).ransack(params[:q])
-    @edits = @q.result(distinct: true)
+    @edits = @q.result(distinct: true).order(created_at: 'desc')
     @user = current_user
   end
 

--- a/app/controllers/edits_controller.rb
+++ b/app/controllers/edits_controller.rb
@@ -10,7 +10,6 @@ helper_method :twitter_datum_ids
 
   def index
     @user = current_user
-    @@user_data = {}
     @edits = Edit.includes(:User).includes(:category)
     @articles = TwitterDatum.all
     @ed = EditsTwitter.all
@@ -23,13 +22,13 @@ helper_method :twitter_datum_ids
   # GET /edits/1.json
   def show
     @categories = Category.all
-    @@user_data = {}
+
     @twes = @edit.edits_twitters.includes(:twitter_datum)
   end
 
   # GET /edits/new
   def new
-    @@user_data = {}
+
     logger.debug("Log0 : " + @@user_data[params[:user_id]].to_s)
     #ページが再読み込みされるのでパラメータを保持
     if params[:select_trend] == nil

--- a/app/controllers/trends_controller.rb
+++ b/app/controllers/trends_controller.rb
@@ -1,19 +1,16 @@
 class TrendsController < ApplicationController
   before_action :set_trend, only: [:show, :edit, :update, :destroy]
   before_action :isauth, only: [:index]
-$twiGetId = Array.new
   # GET /trends
   # GET /trends.json
   def index
-    $twiGetId = Array.new
-    @trends = Trend.all
+    @trends = Trend.all.order(created_at: 'desc')
   end
 
 
   private
     # Use callbacks to share common setup or constraints between actions.
     def set_trend
-      $twiGetId = Array.new
       @trend = Trend.find(params[:id])
     end
 
@@ -24,7 +21,6 @@ $twiGetId = Array.new
     end
     # Never trust parameters from the scary internet, only allow the white list through.
     def trend_params
-      $twiGetId = Array.new
       params.fetch(:trend, {})
     end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -10,13 +10,13 @@ class UsersController < ApplicationController
   # GET /users/1
   # GET /users/1.json
   def show
-    @rankings = Ranking.all 
+    @rankings = Ranking.all
     @categories = Category.all
     unless @user.user_categories.exists?
       redirect_to edit_user_path(@user)
     end
-    @edits = Edit.all
-    @category = Category.all
+    @edits = Edit.all.order(created_at: 'desc')
+    @category = Category.all.order(created_at: 'desc')
   end
 
   # GET /users/new

--- a/app/views/edits/new.html.erb
+++ b/app/views/edits/new.html.erb
@@ -87,8 +87,7 @@ else {
   $('#dropArea').append('<ul><li style="display:none" >'+ id +'</li><li>'+ tweet +'</li><li style="display:none">'+ tweet_id +'</li><li>'+ name +'</li><li>'+ user_id +'</li><li><img src='+ user_icon +'></li><li>'+ date +'</li></ul>');
 }
 }
-
-
+      user_id =  <%= current_user.id%>
       if (id != null) {
       getTwiId.push(id)
     }
@@ -99,12 +98,11 @@ else {
         url: "<%=  edits_add_path  %>",
         type: "POST",
         data: {
-          id: getTwiId
+          id: getTwiId,
+          user_id: user_id
         },
         dataType: "html",
         success: function (data) {
-          var iframe = document.getElementById('dropArea');
-        console.log(iframe)
 
           // $('#test').load(location.href);
           // $('#test').load('<%= new_edit_path %> #test');
@@ -226,7 +224,7 @@ else {
       // endDropzone(name);
       console.log("icon : " + icon)
       doAction(id,name,tweet_id,tweet,user_id,icon,date,img_url,date);
-      doAction(null,name,tweet_id,tweet,user_id,icon,date,img_url,date);
+      // doAction(null,name,tweet_id,tweet,user_id,icon,date,img_url,date);
       onHidden(tweet_id);
     }
 

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -9,7 +9,7 @@
 
 <div class="container container-large">
   <div class="col-md-2 sidebar">
-    <div class="row" style="padding-top: 100px;">  
+    <div class="row" style="padding-top: 100px;">
     <% @categories.each do |category| %>
       <p style="font-size: 20px; padding-bottom: 10px;"><%= link_to category.name, category %></p>
     <% end %>
@@ -30,7 +30,7 @@
             <% else %>
               <% image_url = '/assets/noimage.jpg' %>
             <% end %>
-            
+
             <a href=<%= edit_path(edit) %>>
               <div style="text-align:center;"><img src="<%= image_url %>" alt="" width="100%" style="border: solid 1px #000000;"/></div>
             </a>
@@ -160,8 +160,11 @@
     <% if check == 0 then %>
       <div class="col-md-4" style="background-color: #FFEFD5; margin-bottom: 50px;">
       <h1>ランキング</h1>
+      <% count = 0 %>
       <% @rankings.each do |rank| %>
-      <% @edits.where(id: rank.edit_id).where(category_id: @user.user_categories.find_by(priority: 3).category_id).limit(10).each do |edit| %>
+      <% if count != 10  then %>
+      <% @edits.where(id: rank.edit_id).where(category_id: @user.user_categories.find_by(priority: 3).category_id).each do |edit| %>
+      <% count += 1 %>
         <div class="row">
           <div class="col-md-6">
             <% if edit.url != '' %>
@@ -179,12 +182,16 @@
           </div>
         </div>
         <% end %>
+        <% end %>
     <% end %>
     <% elsif check == 1 then %>
       <div class="col-md-6" style="background-color: #FFEFD5; margin-bottom: 50px;">
       <h1>ランキング</h1>
+      <% count = 0 %>
       <% @rankings.each do |rank| %>
-        <% @edits.where(id: rank.edit_id).where(category_id: @user.user_categories.find_by(priority: 3).category_id).limit(5).each do |edit| %>
+      <% if count != 5  then %>
+      <% @edits.where(id: rank.edit_id).where(category_id: @user.user_categories.find_by(priority: 3).category_id).each do |edit| %>
+      <% count += 1 %>
         <div class="row">
           <div class="col-md-5">
             <% if edit.url != '' %>
@@ -202,12 +209,16 @@
           </div>
         </div>
         <% end %>
+        <% end %>
       <% end %>
     <% elsif check == 2 %>
       <div class="col-md-12" style="background-color: #FFEFD5; margin-bottom: 50px;">
       <h1>ランキング</h1>
+      <% count = 0 %>
       <% @rankings.each do |rank| %>
-      <% @edits.where(id: rank.edit_id).where(category_id: @user.user_categories.find_by(priority: 3).category_id).limit(5).each do |edit| %>
+      <% if count != 5  then %>
+      <% @edits.where(id: rank.edit_id).where(category_id: @user.user_categories.find_by(priority: 3).category_id).each do |edit| %>
+      <% count += 1 %>
         <div class="row">
           <div class="col-md-3">
             <% if edit.url != '' %>
@@ -225,9 +236,9 @@
           </div>
         </div>
         <% end %>
+        <% end %>
     <% end %>
   <% end %>
     </div>
   </div>
 </div>
-

--- a/lib/tasks/rank.rake
+++ b/lib/tasks/rank.rake
@@ -30,7 +30,7 @@ namespace :rank do
   service.authorization.fetch_access_token!
 
   ## 取得するデータの期間を指定する
-  start_date = (DateTime.now - 2).strftime("%Y-%m-%d")
+  start_date = (DateTime.now - 1).strftime("%Y-%m-%d")
   end_date   = DateTime.now.strftime("%Y-%m-%d")
 
   ## URL(pagepath)ごとのページビュー、ユニークページビューを
@@ -61,13 +61,14 @@ namespace :rank do
   gadata.rows.each do |r|
     tmp = r[0].gsub("/edits/","")
     tt = Edit.find_by(id: tmp.to_i)
-
+    if tt != nil then
     ranking = {
       'edit_id' => tt.id,
       'category_id' => tt.category_id
     }
-
     puts "データベース登録" if Ranking.create(ranking)
+  end
+  
     end
   end
 


### PR DESCRIPTION
バグ修正
記事作成時のツイートが登録されないバグ
原因
コントローラを呼び出す際に配列初期化をしていたため他のユーザが
コントローラを呼び出した場合にも適用されていたため
対策
初期化を一回のみとし、ハッシュ関数でユーザを一意に決定。

最新の記事が表示されていないバグを修正。
dbを参照するときに最新の値からとるように変更

ランキング件数を変更
if文で表示件数を制限
